### PR TITLE
Added Minecraft 1.18 support to the get_block method in chunk.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-NBT==1.5.0
+NBT==1.5.1
 frozendict==1.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as file:
 
 setuptools.setup(
     name='anvil-parser',
-    version='0.10.0',
+    version='0.10.1',
     author='mat',
     description='A Minecraft anvil file format parser',
     long_description=long_description,


### PR DESCRIPTION
Minecraft 1.18 has a slight restructuring of NBT tags which has made anvil-parser incompatible with 1.18 worlds. I have added support for 1.18 worlds within the get_block method of chunk.py as well as the methods it depends on (namely __init__ and get_section). I have not added support in other methods like get_biome, stream_blocks, etc. However, one should be able to easily add support for 1.18 in these methods by exacting similar changes to what I have made in get_block.

I also changed the NBT requirement to the most updated version. Other than that I have only modified chunk.py.

I have made this pull request on 0xTiger's fork because it includes the get_biome method.