### PR TITLE
Change version constant for top level tile_entity nbt tag from 1.17.1 to v21w43a

### DIFF
--- a/anvil/chunk.py
+++ b/anvil/chunk.py
@@ -5,9 +5,9 @@ from .block import Block, OldBlock
 from .region import Region
 from .errors import OutOfBoundsCoordinates, ChunkNotFound
 
-# This is the final version before the Minecraft overhaul that includes the 
-# 1.18 expansion of the world's vertical height from -64 to 319
-_VERSION_1_17_1 = 2730
+# This version removes the chunk's "Level" NBT tag and moves all contained tags to the top level
+# https://minecraft.fandom.com/wiki/Java_Edition_21w43a
+_VERSION_21w43a = 2844
 
 # This version removes block state value stretching from the storage
 # so a block value isn't in multiple elements of the array
@@ -99,7 +99,7 @@ class Chunk:
             # See https://minecraft.fandom.com/wiki/Data_version
             self.version = None
 
-        if self.version > _VERSION_1_17_1:
+        if self.version >= _VERSION_21w43a:
             self.data = nbt_data
             self.tile_entities = self.data["block_entities"]
         else:


### PR DESCRIPTION
The version that changed the chunk NBT tags to be at the top-level instead inside a "Level" tag was erroneously set to versions >1.17.1 when it should be >= v21w43a, when this was changed. See the changelog for this version: https://minecraft.fandom.com/wiki/Java_Edition_21w43a

Also just want to say big thank you for maintaining this library and keeping it up to date and alive, you have helped me immensely in keeping my own project up to date.