### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://github.com/matcool/anvil-parser/actions/workflows/run-pytest.yml/badge.svg)](https://github.com/matcool/anvil-parser/actions/workflows/run-pytest.yml)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/anvil-parser)](https://pypi.org/project/anvil-parser/)
 
-Simple parser for the [Minecraft anvil file format](https://minecraft.gamepedia.com/Anvil_file_format)
+Simple parser for the [Minecraft anvil file format](https://minecraft.wiki/w/Anvil_file_format)
 # Installation
 This project is available on [PyPI](https://pypi.org/project/anvil-parser/) and can be installed with pip
 ```

--- a/anvil/block.py
+++ b/anvil/block.py
@@ -94,8 +94,8 @@ class Block:
         data
             Numeric data, used to represent variants of the block
         """
-        # See https://minecraft.gamepedia.com/Java_Edition_data_value/Pre-flattening
-        # and https://minecraft.gamepedia.com/Java_Edition_data_value for current values
+        # See https://minecraft.wiki/w/Java_Edition_data_value/Pre-flattening
+        # and https://minecraft.wiki/w/Java_Edition_data_value for current values
         key = f'{block_id}:{data}'
         if key not in LEGACY_ID_MAP:
             raise KeyError(f'Block {key} not found')

--- a/anvil/chunk.py
+++ b/anvil/chunk.py
@@ -17,7 +17,7 @@ _VERSION_20w17a = 2529
 # https://minecraft.wiki/w/Java_Edition_19w36a
 _VERSION_19w36a = 2203
 
-# This is the version where "The Flattening" (https://minecraft.gamepedia.com/Java_Edition_1.13/Flattening) happened
+# This is the version where "The Flattening" (https://minecraft.wiki/w/Java_Edition_1.13/Flattening) happened
 # where blocks went from numeric ids to namespaced ids (namespace:block_id)
 _VERSION_17w47a = 1451
 
@@ -282,7 +282,7 @@ class Chunk:
             y %= 16
 
         if self.version is None or self.version < _VERSION_17w47a:
-            # Explained in depth here https://minecraft.gamepedia.com/index.php?title=Chunk_format&oldid=1153403#Block_format
+            # Explained in depth here https://minecraft.wiki/w/index.php?title=Chunk_format&oldid=1153403#Block_format
 
             if section is None or "Blocks" not in section:
                 if force_new:

--- a/anvil/chunk.py
+++ b/anvil/chunk.py
@@ -6,7 +6,7 @@ from .region import Region
 from .errors import OutOfBoundsCoordinates, ChunkNotFound
 
 # This version removes the chunk's "Level" NBT tag and moves all contained tags to the top level
-# https://minecraft.fandom.com/wiki/Java_Edition_21w43a
+# https://minecraft.wiki/w/Java_Edition_21w43a
 _VERSION_21w43a = 2844
 
 # This version removes block state value stretching from the storage
@@ -14,7 +14,7 @@ _VERSION_21w43a = 2844
 _VERSION_20w17a = 2529
 
 # This version changes how biomes are stored to allow for biomes at different heights
-# https://minecraft.fandom.com/wiki/Java_Edition_19w36a
+# https://minecraft.wiki/w/Java_Edition_19w36a
 _VERSION_19w36a = 2203
 
 # This is the version where "The Flattening" (https://minecraft.gamepedia.com/Java_Edition_1.13/Flattening) happened
@@ -96,7 +96,7 @@ class Chunk:
             self.version = nbt_data["DataVersion"].value
         except KeyError:
             # Version is pre-1.9 snapshot 15w32a, so world does not have a Data Version.
-            # See https://minecraft.fandom.com/wiki/Data_version
+            # See https://minecraft.wiki/w/Data_version
             self.version = None
 
         if self.version >= _VERSION_21w43a:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 anvil-parser
 ============
 
-Simple parser for the `Minecraft anvil file format <https://minecraft.gamepedia.com/Anvil_file_format/>`_
+Simple parser for the `Minecraft anvil file format <https://minecraft.wiki/w/Anvil_file_format/>`_
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki