### PR TITLE
Bump frozendict version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 NBT==1.5.1
-frozendict==1.2
+frozendict==2.0.2


### PR DESCRIPTION
This PR bumps the version of frozendict to 2.0.2 to support python versions 3.10+.

The currently used version of frozendict (1.2) uses collections.Mapping, which got deprecated in Python 3.10. Updating to frozendict>=2.0.2 fixes this for python versions 3.10+, while keeping compatibility until Python 3.3. 