### PR TITLE
Fix for region saving for versions 1.18+

### DIFF
--- a/anvil/empty_region.py
+++ b/anvil/empty_region.py
@@ -5,6 +5,7 @@ from .empty_section import EmptySection
 from .block import Block
 from .biome import Biome
 from .errors import OutOfBoundsCoordinates
+from .versions import VERSION_21w43a
 from io import BytesIO
 from nbt import nbt
 import zlib
@@ -289,7 +290,12 @@ class EmptyRegion:
             if isinstance(chunk, Chunk):
                 nbt_data = nbt.NBTFile()
                 nbt_data.tags.append(nbt.TAG_Int(name='DataVersion', value=chunk.version))
-                nbt_data.tags.append(chunk.data)
+
+                if chunk.version >= VERSION_21w43a:
+                    for tag in chunk.data.tags:
+                        nbt_data.tags.append(tag)
+                else:
+                    nbt_data.tags.append(chunk.data)
             else:
                 nbt_data = chunk.save()
             nbt_data.write_file(buffer=chunk_data)

--- a/anvil/versions.py
+++ b/anvil/versions.py
@@ -1,0 +1,15 @@
+# This version removes the chunk's "Level" NBT tag and moves all contained tags to the top level
+# https://minecraft.wiki/w/Java_Edition_21w43a
+VERSION_21w43a = 2844
+
+# This version removes block state value stretching from the storage
+# so a block value isn't in multiple elements of the array
+VERSION_20w17a = 2529
+
+# This version changes how biomes are stored to allow for biomes at different heights
+# https://minecraft.wiki/w/Java_Edition_19w36a
+VERSION_19w36a = 2203
+
+# This is the version where "The Flattening" (https://minecraft.wiki/w/Java_Edition_1.13/Flattening) happened
+# where blocks went from numeric ids to namespaced ids (namespace:block_id)
+VERSION_17w47a = 1451


### PR DESCRIPTION
This pull request:

- Moves the data version definitions to a separate file so they can be reused elsewhere. _(If you don't like this, let me know and I'll undo it although this would mean hardcoding the same constant twice though)._
- Fixes region saving for 21w43a and onwards.

As to why the fix works: The issue seemed to be that the chunk data was saved under a blank compound tag, instead of as direct children of the region. So, now for older versions it works the same as before, for newer versions it adds each one individually. 

How it was supposed to look after saving:

![image](https://github.com/0xTiger/anvil-parser/assets/54124297/3c09b04d-e63f-42e9-b274-1f6ab28c2277)

How it was ending up without the fix:

![image](https://github.com/0xTiger/anvil-parser/assets/54124297/2eaf915c-0fb8-4b75-872b-364ac9469ba7)

Now with the fix, it looks identical to the first image.

I'm not 100% sure if this works for all cases. since I use this as part of my tool (<https://github.com/Nyveon/MCStructureCleaner>), the only case I can reliably test it for is region editing. Which is why I'm leaving it as a draft PR for now.

Let me know what you think c:


